### PR TITLE
Android 6 exception resolution

### DIFF
--- a/src/main/java/com/larvalabs/svgandroid/ParserHelper.java
+++ b/src/main/java/com/larvalabs/svgandroid/ParserHelper.java
@@ -18,16 +18,6 @@ import java.lang.reflect.Field;
  */
 public class ParserHelper {
 
-	private static final Field STRING_CHARS;
-	static {
-		try {
-			STRING_CHARS = String.class.getDeclaredField("value");
-			STRING_CHARS.setAccessible(true);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
 	private final char[] s;
 	private final int n;
 	private char current;
@@ -35,7 +25,8 @@ public class ParserHelper {
 
 	public ParserHelper(String str, int pos) {
 		try {
-			this.s = (char[]) STRING_CHARS.get(str);
+			s = new char[str.length()];
+		    str.getChars(0, str.length(), this.s, 0); //(char[]) STRING_CHARS.get(str);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
STRING_CHARS = String.class.getDeclaredField("value");

raises exception

10-09 10:25:58.240: E/AndroidRuntime(3430): Caused by: java.lang.RuntimeException: java.lang.NoSuchFieldException: No field value in class Ljava/lang/String; (declaration of 'java.lang.String' appears in /system/framework/core-libart.jar).

See details on

https://stackoverflow.com/questions/33035866/android-6-0-marshmallow-static-initialization-exception-on-getdeclaredfield
